### PR TITLE
fix: Type mismatch: inferred type is Activity? but Activity was expected

### DIFF
--- a/android/src/main/kotlin/com/whelksoft/camera_with_rtmp/RtmppublisherPlugin.kt
+++ b/android/src/main/kotlin/com/whelksoft/camera_with_rtmp/RtmppublisherPlugin.kt
@@ -42,8 +42,12 @@ public class RtmppublisherPlugin : FlutterPlugin, ActivityAware {
         @JvmStatic
         fun registerWith(registrar: Registrar) {
             val plugin = RtmppublisherPlugin();
+            var activity: Activity? = registrar.activity();
+            if (activity == null) {
+                return;
+            }
             plugin.maybeStartListening(
-                    registrar.activity(),
+                    activity,
                     registrar.messenger(),
                     object : PermissionStuff {
                         override fun adddListener(listener: PluginRegistry.RequestPermissionsResultListener) {

--- a/ios/Classes/RtmppublisherPlugin.m
+++ b/ios/Classes/RtmppublisherPlugin.m
@@ -1081,7 +1081,9 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
                                                                        stringWithFormat:@"plugins.flutter.io/camera_with_rtmp/cameraEvents%lld",
                                                                        textureId]
                                                  binaryMessenger:_messenger];
-            [eventChannel setStreamHandler:cam];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [eventChannel setStreamHandler:cam];
+            });
             cam.eventChannel = eventChannel;
             result(@{
                 @"textureId" : @(textureId),


### PR DESCRIPTION
## 対応内容
- Flutter3へのアップグレード後にandroidでビルドできるように
- Flutter3以上でiosでクラッシュする問題を解消

## 参考
https://github.com/flutter-webrtc/flutter-webrtc/pull/953
https://docs.flutter.dev/development/platform-integration/platform-channels?tab=type-mappings-kotlin-tab#jumping-to-the-main-thread-in-ios